### PR TITLE
fix: kwargs undefined, likely needs to be kwargs_all

### DIFF
--- a/snakemake_interface_common/plugin_registry/plugin.py
+++ b/snakemake_interface_common/plugin_registry/plugin.py
@@ -225,8 +225,8 @@ class PluginBase(ABC):
                 pass
             return tagged_settings
         else:
-            check_required(kwargs)
-            return dc(**kwargs)
+            check_required(kwargs_all)
+            return dc(**kwargs_all)
 
     def get_cli_arg(self, field_name: str) -> str:
         return "--" + self._get_prefixed_name(field_name).replace("_", "-")


### PR DESCRIPTION
problem: the plugin.py registry references kwargs, which is not defined in the location of reference. Likely it needs to be kwargs_all since the if/else it is in checks kwargs_tagged in the top