### PR TITLE
docs: insert space between original help message and suffix

### DIFF
--- a/snakemake_interface_common/plugin_registry/plugin.py
+++ b/snakemake_interface_common/plugin_registry/plugin.py
@@ -160,7 +160,7 @@ class PluginBase(ABC):
                 kwargs["nargs"] = "+"
                 kwargs["type"] = str
                 kwargs["help"] += (
-                    "Can be specified multiple times to set different "
+                    " Can be specified multiple times to set different "
                     "values for different tags."
                 )
                 kwargs["metavar"] = f"[TAG::]{kwargs['metavar']}"


### PR DESCRIPTION
Since plugin authors likely will not end their help messages with a space, the suffix regarding an argument can be specified multiple times should start with a space.