### PR TITLE
feat: make enum listings reproducible and improve formatting

### DIFF
--- a/snakemake_interface_common/settings.py
+++ b/snakemake_interface_common/settings.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from enum import Enum
-from typing import FrozenSet, List, Set, TypeVar
+from typing import FrozenSet, List, Set, Tuple, TypeVar
 
 TSettingsEnumBase = TypeVar("TSettingsEnumBase", bound="SettingsEnumBase")
 
@@ -8,12 +8,12 @@ TSettingsEnumBase = TypeVar("TSettingsEnumBase", bound="SettingsEnumBase")
 class SettingsEnumBase(Enum):
     @classmethod
     def choices(cls) -> List[str]:
-        return sorted(item.item_to_choice() for item in cls)
+        return list(item.item_to_choice() for item in cls)
 
     @classmethod
-    def all(cls) -> FrozenSet[TSettingsEnumBase]:
+    def all(cls) -> Tuple[TSettingsEnumBase]:
         skip = cls.skip_for_all()
-        return frozenset(item for item in cls if item not in skip)
+        return tuple(item for item in cls if item not in skip)
 
     @classmethod
     def parse_choices_list(cls, choices: List[str]) -> List[TSettingsEnumBase]:


### PR DESCRIPTION
I'm rebuilding RPM packages to check build reproducibility (https://docs.fedoraproject.org/en-US/reproducible-builds/), and we got the result that rebuilds of the snakemake man page varies in this trivial way:

│ │ │  \fB\-\-rerun\-trigger\fR mtime'. (default:
│ │ │ -frozenset({<RerunTrigger.INPUT: 2>,
│ │ │ -<RerunTrigger.MTIME: 0>, <RerunTrigger.SOFTWARE_ENV: │ │ │ -3>, <RerunTrigger.PARAMS: 1>, <RerunTrigger.CODE: │ │ │ -4>}))
│ │ │ +frozenset({<RerunTrigger.CODE: 4>,
│ │ │ +<RerunTrigger.PARAMS: 1>, <RerunTrigger.INPUT: 2>, │ │ │ +<RerunTrigger.SOFTWARE_ENV: 3>, <RerunTrigger.MTIME: │ │ │ +0>}))

sets/frozensets are hash-ordered, not insertion ordered, so the order is not reproducible. Also, the automatic formatting in --help looks bad, the fact that it's a frozenset is not interesting to the user.

If we drop the explicit sorting, the items are sorted in the definition order, which seems reasonable.

--help text with the patch:
  --rerun-triggers {mtime,params,input,software-env,code} [{mtime,params,input,software-env,code} ...]
                        Define what triggers the rerunning of a job. By
                        default, all triggers are used, which guarantees that
                        results are consistent with the workflow code and
                        configuration. If you rather prefer the traditional
                        way of just considering file modification dates, use '
                        --rerun-trigger mtime'. (default:
                        (<RerunTrigger.MTIME: 0>, <RerunTrigger.PARAMS: 1>,
                        <RerunTrigger.INPUT: 2>, <RerunTrigger.SOFTWARE_ENV:
                        3>, <RerunTrigger.CODE: 4>))