### PR TITLE
fix: set CLI arg type to str if parse_func is provided

### DIFF
--- a/snakemake_interface_common/plugin_registry/plugin.py
+++ b/snakemake_interface_common/plugin_registry/plugin.py
@@ -165,6 +165,9 @@ class PluginBase(ABC):
                 )
                 kwargs["metavar"] = f"[TAG::]{kwargs['metavar']}"
 
+            if thefield.metadata.get("parse_func"):
+                kwargs["type"] = str
+
             settings.add_argument(*args, **kwargs)
 
     def validate_settings(self, settings):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced command-line argument parsing to include dynamic type specification based on metadata attributes.
  
- **Bug Fixes**
  - Improved accuracy in parsing command-line arguments, ensuring they align with intended types.

These updates aim to provide a more flexible and user-friendly command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->