### PR TITLE
fix: fix misleading CLI help text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.20.0"
 description = "Common functions and classes for Snakemake and its plugins"
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = ["argparse-dataclass>=2.0.0", "ConfigArgParse>=1.7", "packaging >=25.0,<26.0"]
+dependencies = ["argparse-dataclass>=2.0.0", "ConfigArgParse>=1.7", "packaging >=24.0,<26.0"]
 
 [[project.authors]]
 name = "Johannes Koester"

--- a/src/snakemake_interface_common/plugin_registry/plugin.py
+++ b/src/snakemake_interface_common/plugin_registry/plugin.py
@@ -96,7 +96,7 @@ class PluginBase(ABC, Generic[TSettingsBase]):
         return False
 
     def has_settings_cls(self) -> bool:
-        """Determine if a plugin defines custom executor settings"""
+        """Determine if a plugin defines custom settings"""
         return self.settings_cls is not None
 
     def get_settings_info(self) -> List[Dict[str, Any]]:
@@ -151,7 +151,7 @@ class PluginBase(ABC, Generic[TSettingsBase]):
                     self.name, "Fields of ExecutorSettings must have a default value."
                 )
 
-        settings = argparser.add_argument_group(f"{self.name} executor settings")
+        settings = argparser.add_argument_group(f"{self.name} plugin settings")
 
         for thefield in fields(params):
             prefixed_name = self._get_prefixed_name(thefield.name).replace("-", "_")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated user-facing labels and descriptions to refer to "plugin settings" instead of "executor settings" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->