### PR TITLE
feat: add functionality to infer plugin type from registry class name and use that to provide better CLI help texts

### DIFF
--- a/src/snakemake_interface_common/plugin_registry/__init__.py
+++ b/src/snakemake_interface_common/plugin_registry/__init__.py
@@ -4,6 +4,7 @@ __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
 from abc import ABC, abstractmethod
+import re
 import types
 import pkgutil
 import importlib
@@ -64,8 +65,19 @@ class PluginRegistryBase(ABC, Generic[TPlugin]):
     def register_cli_args(self, argparser: "ArgumentParser") -> None:
         """Add arguments derived from self.executor_settings to given
         argparser."""
+        plugin_type = self.get_plugin_type()
         for _, plugin in self.plugins.items():
-            plugin.register_cli_args(argparser)
+            plugin.register_cli_args(argparser, plugin_type)
+
+    def get_plugin_type(self) -> str:
+        m = re.match(r"(?P<type>).+)PluginRegistry", self.__name__)
+        if m is not None:
+            return m.group("type").lower()
+        raise ValueError(
+            "Unable to infer plugin type name from registry class "
+            f"name: {self.__name__}. The name is expected to follow the "
+            "pattern <type>PluginRegistry, e.g. ExecutorPluginRegistry."
+        )
 
     def collect_plugins(self) -> None:
         """Collect plugins and call register_plugin for each."""

--- a/src/snakemake_interface_common/plugin_registry/__init__.py
+++ b/src/snakemake_interface_common/plugin_registry/__init__.py
@@ -70,12 +70,12 @@ class PluginRegistryBase(ABC, Generic[TPlugin]):
             plugin.register_cli_args(argparser, plugin_type)
 
     def get_plugin_type(self) -> str:
-        m = re.match(r"(?P<type>).+)PluginRegistry", self.__name__)
+        m = re.match(r"(?P<type>.+)PluginRegistry", self.__class__.__name__)
         if m is not None:
             return m.group("type").lower()
         raise ValueError(
             "Unable to infer plugin type name from registry class "
-            f"name: {self.__name__}. The name is expected to follow the "
+            f"name: {self.__class__.__name__}. The name is expected to follow the "
             "pattern <type>PluginRegistry, e.g. ExecutorPluginRegistry."
         )
 

--- a/src/snakemake_interface_common/plugin_registry/plugin.py
+++ b/src/snakemake_interface_common/plugin_registry/plugin.py
@@ -130,7 +130,7 @@ class PluginBase(ABC, Generic[TSettingsBase]):
                 for thefield in fields(self.settings_cls)
             ]
 
-    def register_cli_args(self, argparser: "ArgumentParser") -> None:
+    def register_cli_args(self, argparser: "ArgumentParser", plugin_type: str) -> None:
         """Add arguments derived from self.executor_settings to given
         argparser."""
 
@@ -151,7 +151,7 @@ class PluginBase(ABC, Generic[TSettingsBase]):
                     self.name, "Fields of ExecutorSettings must have a default value."
                 )
 
-        settings = argparser.add_argument_group(f"{self.name} plugin settings")
+        settings = argparser.add_argument_group(f"{self.name} {plugin_type} plugin settings")
 
         for thefield in fields(params):
             prefixed_name = self._get_prefixed_name(thefield.name).replace("-", "_")

--- a/src/snakemake_interface_common/plugin_registry/plugin.py
+++ b/src/snakemake_interface_common/plugin_registry/plugin.py
@@ -151,7 +151,9 @@ class PluginBase(ABC, Generic[TSettingsBase]):
                     self.name, "Fields of ExecutorSettings must have a default value."
                 )
 
-        settings = argparser.add_argument_group(f"{self.name} {plugin_type} plugin settings")
+        settings = argparser.add_argument_group(
+            f"{self.name} {plugin_type} plugin settings"
+        )
 
         for thefield in fields(params):
             prefixed_name = self._get_prefixed_name(thefield.name).replace("-", "_")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved command-line interface by displaying plugin type in argument group labels for plugin settings.

* **Refactor**
  * Enhanced internal handling of plugin type detection and argument registration for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->