### PR TITLE
feat: expand variables and user dirs in settings of type Path.

### DIFF
--- a/src/snakemake_interface_common/plugin_registry/plugin.py
+++ b/src/snakemake_interface_common/plugin_registry/plugin.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import field, fields, Field
 from dataclasses import MISSING, dataclass
+import os
 from pathlib import Path
 from typing import (
     Any,
@@ -273,6 +274,11 @@ class PluginBase(ABC, Generic[TSettingsBase]):
                         )
                     elif thefield.type != str and isinstance(thefield.type, type):
                         value = self._parse_type(thefield, value, thefield.type)
+
+                    # expand variables and user dirs in paths
+                    if isinstance(value, Path):
+                        value = Path(os.path.expandvars(str(value.expanduser())))
+
                     if tag is None:
                         kwargs_all[name] = value
                     else:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically expands user home (~) and environment variables in plugin path settings before use, ensuring resolved, usable paths.
  * Applies to all Path-based configuration values during settings extraction for consistent behavior across environments.
  * Reduces manual configuration by accepting shorthand and environment-based paths in plugin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->