### PR TITLE
fix: add help text for user dir and env var expansion

### DIFF
--- a/src/snakemake_interface_common/plugin_registry/plugin.py
+++ b/src/snakemake_interface_common/plugin_registry/plugin.py
@@ -167,6 +167,11 @@ class PluginBase(ABC, Generic[TSettingsBase]):
             if "metavar" not in kwargs:
                 kwargs["metavar"] = "VALUE"
 
+            if thefield.type == Path:
+                kwargs["help"] += (
+                    " User dir (~) and environment variables are properly interpreted."
+                )
+
             if thefield.type == bool:
                 # boolean args may not have a metavar
                 del kwargs["metavar"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved CLI help text for path options to clarify that home (~) and environment variables are expanded automatically, enhancing usability across all Path-type options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->